### PR TITLE
Create apiClient and pass the base url

### DIFF
--- a/swa-calderilla-fe/src/api/apiClient.ts
+++ b/swa-calderilla-fe/src/api/apiClient.ts
@@ -1,0 +1,13 @@
+import { OtherEndpointsClient } from "./apiClient.g.nswag";
+
+class ApiClient {
+  public readonly otherEndpoints: OtherEndpointsClient;
+
+  constructor() {
+      this.otherEndpoints = new OtherEndpointsClient("/api");
+  }
+}
+
+const apiClient = new ApiClient();
+
+export default apiClient;

--- a/swa-calderilla-fe/src/features/WelcomeMessage/index.tsx
+++ b/swa-calderilla-fe/src/features/WelcomeMessage/index.tsx
@@ -1,6 +1,6 @@
 /* eslint-disable @typescript-eslint/no-misused-promises */
 import { useState } from "react";
-import { OtherEndpointsClient } from "../../api/apiClient.g.nswag";
+import apiClient from "../../api/apiClient";
 
 const WelcomeMessage = () => {
   const [loading, setLoading] = useState(false);
@@ -11,8 +11,8 @@ const WelcomeMessage = () => {
     setLoading(true);
     setError(null); // Clear previous errors
     try {
-      const client = new OtherEndpointsClient();
-      const message = await client.getMessage();
+
+      const message = await apiClient.otherEndpoints.getMessage();
       setApiResponse(message);
     } catch (err) {
       if (err instanceof Error) {


### PR DESCRIPTION
Create apiClient and pass the base url

#### PR Classification
Code cleanup and improvement of code structure.

#### PR Summary
Centralizes API client instantiation and improves code maintainability by introducing a new `ApiClient` class.
- `apiClient.ts`: Introduces `ApiClient` class encapsulating `OtherEndpointsClient` with a base URL of "/api" and exports it as a singleton instance.
- `index.tsx`: Replaces `OtherEndpointsClient` import with `apiClient` instance and updates `fetchApiData` to use `apiClient` for API calls.
